### PR TITLE
Add OpenRouter AI chat Neovim pack plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# AI Chat Neovim Pack Addon
+
+A minimal chat helper for Neovim that talks to OpenRouter. Install it with `vim.pack.add()` and start chatting with `:ai`.
+
+## Installation
+```lua
+-- If you cloned this repository locally, point `dir` to its path.
+vim.pack.add('ai-chat', { dir = '/path/to/meetease' })
+
+require('ai_chat').setup({
+  api_key = os.getenv('OPENROUTER_API_KEY'),
+  model = 'openrouter/<your-model>',
+  -- optional window tweaks
+  -- window = { width = 0.7, height = 0.7, border = 'single' },
+})
+```
+
+## Usage
+Run `:ai` (or `:Ai`) to open a floating chat window. The command immediately prompts for your message, sends it to OpenRouter, and streams follow-up prompts after each reply. Close the prompt or leave it empty to stop chatting.
+
+## Notes
+- Requires `curl` available in your `$PATH`.
+- Uses `vim.system` when available (Neovim ≥ 0.10) and falls back to `vim.fn.system` otherwise.

--- a/lua/ai_chat/init.lua
+++ b/lua/ai_chat/init.lua
@@ -1,0 +1,169 @@
+local M = {}
+
+local state = {
+  messages = {},
+  buf = nil,
+  win = nil,
+}
+
+local config = {
+  api_key = nil,
+  model = nil,
+  base_url = "https://openrouter.ai/api/v1/chat/completions",
+  window = {
+    width = 0.6,
+    height = 0.6,
+    border = "rounded",
+  },
+}
+
+local function notify(msg, level)
+  vim.notify("ai-chat: " .. msg, level or vim.log.levels.INFO)
+end
+
+local function render_buffer()
+  if not state.buf or not vim.api.nvim_buf_is_valid(state.buf) then
+    return
+  end
+  local lines = {}
+  for _, message in ipairs(state.messages) do
+    local prefix = message.role == "user" and "You" or "AI"
+    table.insert(lines, prefix .. ": " .. message.content)
+    table.insert(lines, "")
+  end
+  vim.api.nvim_buf_set_lines(state.buf, 0, -1, false, lines)
+  vim.api.nvim_buf_set_option(state.buf, "modifiable", false)
+end
+
+local function ensure_window()
+  if state.win and vim.api.nvim_win_is_valid(state.win) then
+    return
+  end
+  if not state.buf or not vim.api.nvim_buf_is_valid(state.buf) then
+    state.buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(state.buf, "AI Chat")
+    vim.api.nvim_buf_set_option(state.buf, "filetype", "ai-chat")
+  end
+
+  local width = math.floor(vim.o.columns * config.window.width)
+  local height = math.floor(vim.o.lines * config.window.height)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  state.win = vim.api.nvim_open_win(state.buf, true, {
+    relative = "editor",
+    style = "minimal",
+    border = config.window.border,
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+  })
+  vim.api.nvim_win_set_option(state.win, "wrap", true)
+end
+
+local function request_chat(payload, callback)
+  local headers = {
+    "-H",
+    "Content-Type: application/json",
+    "-H",
+    "Authorization: Bearer " .. config.api_key,
+  }
+  local cmd = {
+    "curl",
+    "-sS",
+    "-X",
+    "POST",
+    config.base_url,
+  }
+  vim.list_extend(cmd, headers)
+  table.insert(cmd, "-d")
+  table.insert(cmd, vim.fn.json_encode(payload))
+
+  local function handle_result(stdout, code, stderr)
+    if code ~= 0 then
+      callback(nil, stderr ~= "" and stderr or stdout)
+      return
+    end
+    local ok, parsed = pcall(vim.json.decode, stdout)
+    if not ok then
+      callback(nil, "Failed to decode response: " .. stdout)
+      return
+    end
+    local choice = parsed.choices and parsed.choices[1]
+    local content = choice and choice.message and choice.message.content
+    if not content then
+      callback(nil, "Unexpected response from API")
+      return
+    end
+    callback(content)
+  end
+
+  if vim.system then
+    vim.system(cmd, { text = true }, function(result)
+      handle_result(result.stdout, result.code, result.stderr)
+    end)
+  else
+    local output = vim.fn.system(cmd)
+    handle_result(output, vim.v.shell_error, "")
+  end
+end
+
+local function prompt_user()
+  vim.schedule(function()
+    vim.ui.input({ prompt = "You: " }, function(input)
+      if not input or input == "" then
+        notify("Chat closed")
+        return
+      end
+      table.insert(state.messages, { role = "user", content = input })
+      render_buffer()
+      vim.api.nvim_buf_set_option(state.buf, "modifiable", true)
+      table.insert(state.messages, { role = "assistant", content = "..." })
+      render_buffer()
+      request_chat({
+        model = config.model,
+        messages = state.messages,
+      }, function(response, err)
+        table.remove(state.messages) -- remove placeholder
+        if not response then
+          notify(err or "Request failed", vim.log.levels.ERROR)
+          render_buffer()
+          return
+        end
+        table.insert(state.messages, { role = "assistant", content = response })
+        render_buffer()
+        prompt_user()
+      end)
+    end)
+  end)
+end
+
+function M.start()
+  if not config.api_key or config.api_key == "" then
+    notify("API key missing. Set it via require('ai_chat').setup({ api_key = ... })", vim.log.levels.ERROR)
+    return
+  end
+  if not config.model or config.model == "" then
+    notify("Model missing. Set it via require('ai_chat').setup({ model = ... })", vim.log.levels.ERROR)
+    return
+  end
+  state.messages = {}
+  ensure_window()
+  render_buffer()
+  prompt_user()
+end
+
+function M.setup(opts)
+  opts = opts or {}
+  config.api_key = opts.api_key or config.api_key
+  config.model = opts.model or config.model
+  if opts.base_url then
+    config.base_url = opts.base_url
+  end
+  if opts.window then
+    config.window = vim.tbl_deep_extend("force", config.window, opts.window)
+  end
+end
+
+return M

--- a/plugin/ai_chat.lua
+++ b/plugin/ai_chat.lua
@@ -1,0 +1,20 @@
+if vim.g.loaded_ai_chat then
+  return
+end
+vim.g.loaded_ai_chat = true
+
+vim.api.nvim_create_user_command("Ai", function(opts)
+  local ok, chat = pcall(require, "ai_chat")
+  if not ok then
+    vim.notify("ai-chat: failed to load module: " .. chat, vim.log.levels.ERROR)
+    return
+  end
+  chat.start()
+end, {
+  desc = "Open a minimal AI chat powered by OpenRouter",
+})
+
+-- alias to allow :ai usage
+vim.api.nvim_create_user_command("ai", function()
+  vim.cmd("Ai")
+end, { desc = "Alias for :Ai" })


### PR DESCRIPTION
## Summary
- add a minimal Lua module that opens a floating chat buffer and sends prompts to OpenRouter
- register :Ai/:ai commands so the pack plugin can be started after vim.pack.add
- document installation and configuration steps for the plugin

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944823c39a08322ad5b454b984584be)